### PR TITLE
fix(treemap): make totalValue optional and simplify label logic

### DIFF
--- a/frontend/src/components/charts/AntTreemapChart.vue
+++ b/frontend/src/components/charts/AntTreemapChart.vue
@@ -13,7 +13,7 @@ const props = defineProps({
   color: [Array, Function],
   totalValue: {
     type: Number,
-    required: true,
+    required: false,
   }
 });
 
@@ -37,10 +37,8 @@ const renderChart = () => {
         
         label: {
             formatter: (d) => {
-                const percentage = props.totalValue > 0 ? (d.value / props.totalValue * 100).toFixed(2) : 0;
-
-                if (d.value / props.totalValue > 0.05) {
-                    return `${d.name}\n${percentage}%`;
+                if (d.value) {
+                    return `${d.name}\n${d.value}`;
                 }
                 return '';
             },
@@ -63,7 +61,7 @@ onMounted(() => {
   renderChart();
 });
 
-watch(() => [props.data, props.totalValue], () => {
+watch(() => props.data, () => {
   renderChart();
 }, { deep: true });
 

--- a/frontend/src/utils/dataTransformer.js
+++ b/frontend/src/utils/dataTransformer.js
@@ -11,11 +11,11 @@ export function transformApiDataToCharts(apiData) {
 
   // --- Treemap Data ---
   const treemapData = groupDistributionData
-    .filter(item => item && item.AssignmentGroup)
-    .map(item => ({
-      name: item.AssignmentGroup,
-      value: item.Count
-    }));
+  .filter(item => item && item.AssignmentGroup)
+  .map(item => ({
+    name: item.AssignmentGroup,
+    value: item.Count
+  }));
 
   // --- Priority Pie Chart Data ---
   const priorityCount = cleanedServiceData.reduce((acc, item) => {


### PR DESCRIPTION
Make totalValue prop optional in AntTreemapChart to increase flexibility.
Update label formatter to display raw values instead of percentages when
totalValue is not provided or zero. Remove unnecessary watch on totalValue
to avoid redundant renders. Clean up dataTransformer formatting for consistency.