### PR TITLE
feat(charts): add color prop and update color schemes

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -37,32 +37,28 @@
     >
       <div style="max-width: 1600px; margin: 0 auto; display: flex; flex-direction: column; height: 100%;">
         <a-spin :spinning="state.loading" size="large" tip="Đang tải dữ liệu..." style="display: flex; flex-direction: column; height: 100%;">
-          
-          <!-- Hàng 1: KPI Cards -->
+
           <a-row :gutter="[24, 24]" style="flex: 0 0 auto;">
             <a-col :xs="24" :sm="24" :md="8"><KpiCard title="Tổng số Incident" :value="state.kpi.total" theme="info" /></a-col>
             <a-col :xs="24" :sm="12" :md="8"><KpiCard title="Số Incident Nghiêm trọng" :value="state.kpi.highPriority" theme="danger" /></a-col>
             <a-col :xs="24" :sm="12" :md="8"><KpiCard :title="state.kpi.latestTitle" :value="state.kpi.latestValue" theme="warning" /></a-col>
           </a-row>
-          
-          <!-- Wrapper cho các biểu đồ -->
+
           <div style="flex: 1 1 auto; display: flex; flex-direction: column; justify-content: center; margin-top: 24px; min-height: 0;">
-            
-            <!-- Hàng 2: Chứa 2 biểu đồ quan trọng -->
+
             <a-row :gutter="[24, 24]">
               <a-col :xs="24" :lg="12">
                 <a-card title="Số lượng Incident theo Mức độ Ưu tiên trong các Service" :bordered="false" class="limited-height-card">
-                  <AntStackedBarChart :data="state.charts.servicePriority.data" x-field="service" y-field="count" series-field="priority" :color="getBarPriorityColor" />
+                  <AntStackedBarChart :data="sortedServicePriorityData" x-field="service" y-field="count" series-field="priority" :color="getBarPriorityColor" />
                 </a-card>
               </a-col>
               <a-col :xs="24" :lg="12">
                 <a-card title="Xu hướng Incident theo Nhóm DAEO và NON-DAEO" :bordered="false" class="limited-height-card">
-                  <AntMultiLineChart :data="state.charts.trendByDaeo.data" x-field="time" y-field="count" series-field="group" />
+                  <AntMultiLineChart :data="state.charts.trendByDaeo.data" x-field="time" y-field="count" series-field="group" :color="groupColors"/>
                 </a-card>
               </a-col>
             </a-row>
 
-            <!-- Hàng 3: Chứa 3 biểu đồ còn lại -->
             <a-row :gutter="[24, 24]" style="margin-top: 24px;">
               <a-col :xs="24" :lg="8">
                 <a-card title="Tỷ trọng Incident theo Mức độ Ưu tiên" :bordered="false" class="limited-height-card">
@@ -76,7 +72,7 @@
               </a-col>
               <a-col :xs="24" :lg="8">
                 <a-card title="Tổng số Incident theo Ca" :bordered="false" class="limited-height-card">
-                  <AntDrillBarChart :data="state.charts.shiftPriority.data" :filters="filters" />
+                  <AntDrillBarChart :data="state.charts.shiftPriority.data" :filters="filters" :color="groupColors" />
                 </a-card>
               </a-col>
             </a-row>
@@ -115,18 +111,40 @@ const assignmentGroupOptions = computed(() => {
 });
 
 const groupColors = [
-  '#5B8FF9', '#61DDAA', '#65789B', '#F6BD16', '#7262FD', 
-  '#78D3F8', '#9661BC', '#F6903D', '#008BB4'
+  '#0072B2', // Xanh dương đậm
+  '#E69F00', // Vàng cam
+  '#56B4E9', // Xanh da trời
+  '#009E73', // Xanh lá cây (ngả lam)
+  '#CC79A7', // Hồng tím
+  '#D55E00', // Cam đỏ (Vermilion)
+  '#F0E442', // Vàng chanh
+  '#882255', // Đỏ rượu vang (Maroon)
+  '#44AA99', // Xanh bạc hà (Teal)
+  '#888888', // Xám trung tính
 ];
 
 const priorityColorMap = {
-  'Critical': '#FF4D4F',
-  'High': '#FA8C16',
-  'Moderate': '#FADB14',
-  'Low': '#52C41A',
+  'Critical': '#D55E00',
+  'High': '#C19A00',
+  'Moderate': '#332288',
+  'Low': '#56B4E9',
 };
 const getPiePriorityColor = ({ type }) => priorityColorMap[type] || '#E8E8E8';
 const getBarPriorityColor = ({ priority }) => priorityColorMap[priority] || '#E8E8E8';
+
+const sortedServicePriorityData = computed(() => {
+  const priorityOrder = ['Critical', 'High', 'Moderate', 'Low'];
+
+  if (!state.charts.servicePriority.data) {
+    return [];
+  }
+  
+  return [...state.charts.servicePriority.data].sort((a, b) => {
+    const indexA = priorityOrder.indexOf(a.priority);
+    const indexB = priorityOrder.indexOf(b.priority);
+    return indexA - indexB;
+  });
+});
 
 watch(filters, (newFilters) => {
   updateDashboardData(newFilters);
@@ -151,7 +169,6 @@ onMounted(() => {
   flex-direction: column;
 }
 
-/* Đảm bảo component chart bên trong cũng co giãn */
 .limited-height-card :deep(.ant-card-body > div) {
     flex: 1;
     min-height: 0;

--- a/frontend/src/components/charts/AntDrillBarChart.vue
+++ b/frontend/src/components/charts/AntDrillBarChart.vue
@@ -21,15 +21,16 @@ import { Column, Pie } from '@antv/g2plot';
 import { fetchShiftPriorityDetails } from '@/services/api.js';
 
 const priorityColorMap = {
-    'Critical': '#FF4D4F',
-    'High': '#FA8C16',
-    'Moderate': '#FADB14',
-    'Low': '#52C41A',
+    'Critical': '#D55E00',
+    'High': '#C19A00',
+    'Moderate': '#332288',
+    'Low': '#56B4E9',
 };
 
 const props = defineProps({
     data: { type: Array, required: true },
     filters: { type: Object, required: true },
+    color: { type: Array }, 
 });
 
 const tooltip = reactive({
@@ -115,6 +116,7 @@ const renderChart = () => {
         yField: 'total_sales',
         seriesField: 'type',
         legend: { position: 'top-left' },
+        color: props.color,
         columnWidthRatio: 0.5,
         columnStyle: {
             radius: [4, 4, 0, 0],

--- a/frontend/src/components/charts/AntMultiLineChart.vue
+++ b/frontend/src/components/charts/AntMultiLineChart.vue
@@ -11,6 +11,7 @@ const props = defineProps({
   xField: String,
   yField: String,
   seriesField: String,
+  color: Array,
 });
 
 const container = ref(null);
@@ -28,6 +29,7 @@ const renderChart = () => {
         xField: props.xField,
         yField: props.yField,
         seriesField: props.seriesField,
+        color: props.color,
         smooth: false,
         legend: { 
             position: 'top-right' 

--- a/frontend/src/components/charts/AntStackedBarChart.vue
+++ b/frontend/src/components/charts/AntStackedBarChart.vue
@@ -33,6 +33,13 @@ const renderChart = () => {
         label: {
           position: 'middle',
           layout: [{ type: 'interval-adjust-position' }],
+          style: {
+            fill: '#fff',
+            fontSize: 10,
+            fontStyle: 400,
+            textShadow: '1px 1px 2px black',
+          },
+          
         },
         legend: {
           position: 'right-top',

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: 'https://localhost:7034',
+  baseURL: 'http://localhost:5007',
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
- Add optional color prop to AntDrillBarChart and AntMultiLineChart to allow
  custom color palettes for chart series.
- Update priorityColorMap in AntDrillBarChart with new color values for better
  visual distinction.
- Pass color props from parent components to charts for consistent theming.
- Refactor App.vue to use sorted data and apply groupColors array for charts.
- Update groupColors with a refined palette for improved accessibility and
  aesthetics.
- Change API baseURL to correct localhost port for backend connectivity.

These changes improve chart customization and visual clarity while fixing API  
connection settings.