### PR TITLE
fix(frontend): bind date picker mode to filters.mode property

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -23,7 +23,7 @@
             <a-radio-button value="month">Tháng</a-radio-button>
             <a-radio-button value="year">Năm</a-radio-button>
           </a-radio-group>
-          <a-date-picker v-model:value="filters.date" :picker="mode" :allow-clear="false" />
+          <a-date-picker v-model:value="filters.date" :picker="filters.mode" :allow-clear="false" />
         </a-space>
       </div>
     </a-layout-header>


### PR DESCRIPTION
Update the a-date-picker component to use filters.mode instead of
mode directly. This ensures the picker mode is correctly reactive
to the filters object, fixing a potential mismatch in the UI state.